### PR TITLE
Git stash basics (2025-09-27)

### DIFF
--- a/til/2025-09-27-git-stash.md
+++ b/til/2025-09-27-git-stash.md
@@ -1,0 +1,7 @@
+# TIL — Git: stash basics
+Date: 2025-09-27
+
+Summary:
+- `git stash` saves uncommitted changes temporarily.
+- `git stash pop` restores and removes from stash.
+- `git stash apply` restores but keeps in stash.


### PR DESCRIPTION
Adds a TIL entry explaining the basics of `git stash`.

Small docs-only addition.
